### PR TITLE
[PR] 로그인 API 구현 및 Controller 코드 수정

### DIFF
--- a/src/main/java/com/sw/journal/journalcrawlerpublisher/controller/MemberRestController.java
+++ b/src/main/java/com/sw/journal/journalcrawlerpublisher/controller/MemberRestController.java
@@ -83,9 +83,24 @@ public class MemberRestController {
         return ResponseEntity.ok("인증번호가 발송되었습니다.");
     }
 
-    // 이메일 인증 코드 검증
-    @PostMapping("/verify-code")
-    public ResponseEntity<?> verifyCode(
+    // 이메일 인증 코드 검증 (회원가입 할 때)
+    @PostMapping("/verify-code-signup")
+    public ResponseEntity<?> verifyCodeToSignUp(
+            // 사용자가 입력한 email, 인증번호를 body로 받음
+            @RequestBody VerificationDTO request) throws IOException {
+        // 인증 번호와 사용자 입력 코드 비교
+        if (!memberService.verifyCode(request.getEmail(), request.getCode())) {
+            return ResponseEntity.badRequest().body("인증코드가 일치하지 않습니다.");
+        }
+
+        // 인증 성공 후 DB에서 인증번호 삭제
+        memberService.deleteCode(request.getEmail());
+        return ResponseEntity.ok("인증이 완료되었습니다.");
+    }
+
+    // 이메일 인증 코드 검증 (비밀번호 재설정할 때)
+    @PostMapping("/verify-code-change-pw")
+    public ResponseEntity<?> verifyCodeToChangePw(
             // 사용자가 입력한 email, 인증번호를 body로 받음
             @RequestBody VerificationDTO request) throws IOException {
         Map<String, String> response = new HashMap<>();
@@ -104,7 +119,7 @@ public class MemberRestController {
             return ResponseEntity.badRequest().body("사용자를 찾을 수 없습니다.");
         } else {
             response.put("message", "인증이 완료되었습니다.");
-            response.put("email", member.get().getEmail());
+            response.put("id", member.get().getUsername());
         }
         return ResponseEntity.ok(response);
     }
@@ -227,34 +242,36 @@ public class MemberRestController {
     // 비밀번호 재설정
     @PostMapping("/change-password")
     public ResponseEntity<String> changePassword(
+            // action을 통해 user ID 표시 또는 비밀번호 변경 중 선택
             @RequestParam("action") String action,
+            // user ID 표시하기 위해 RequestParam으로 user ID를 전달 받음
+            @RequestParam("id") String id,
+            // 사용자가 입력한 new password, Confirm password 값 비교하기 위한 DTO
             @RequestBody ChangePwDTO request) {
-        // 사용자 인증
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        String currentUsername = authentication.getName();
-        Optional<Member> member = memberRepository.findByUsername(currentUsername);
-
-        // 권한 없음
+        // RequestParam을 통해 전달 받은 user ID로 사용자 검색
+        Optional<Member> member = memberRepository.findByUsername(id);
+        // 전달 받은 user ID의 사용자가 존재하지 않을때
         if (member.isEmpty()) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(null);
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("사용자를 찾을 수 없습니다.");
         }
-        Member currentMember = member.get();
 
-        // action을 통해 id 표시 또는 비밀번호 변경 중 선택
         switch (action) {
+            // user ID 표시하는 부분
             // show_id일때는 body 값 {}로 보내야함
             case "show_id" :
-                return ResponseEntity.ok(currentUsername);
+                return ResponseEntity.ok(id);
+            // new password, Confirm password 부분
             case "change_password" :
+                // new password, Confirm password 일치하지 않을 때
                 if (!request.getNewPw().equals(request.getNewPwConfirm())) {
                     return ResponseEntity.badRequest().body("비밀번호가 맞지 않습니다.");
+                // 일치할시 비밀번호가 성공적으로 변경됨
+                } else {
+                    Member Targetmember = member.get();
+                    Targetmember.setPassword(passwordEncoder.encode(request.getNewPw()));
+                    memberRepository.save(Targetmember);
+                    return ResponseEntity.ok("비밀번호가 성공적으로 변경되었습니다.");
                 }
-                // 비밀번호 변경
-                if (!request.getNewPw().isEmpty()) {
-                    currentMember.setPassword(passwordEncoder.encode(request.getNewPw()));
-                }
-                memberRepository.save(currentMember);
-                return ResponseEntity.ok("비밀번호가 성공적으로 변경되었습니다.");
             default:
                 return ResponseEntity.badRequest().body("잘못된 요청입니다.");
         }

--- a/src/main/java/com/sw/journal/journalcrawlerpublisher/domain/LoginDTO.java
+++ b/src/main/java/com/sw/journal/journalcrawlerpublisher/domain/LoginDTO.java
@@ -1,0 +1,13 @@
+package com.sw.journal.journalcrawlerpublisher.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@RequiredArgsConstructor
+public class LoginDTO {
+    String id;
+    String password;
+}

--- a/src/main/java/com/sw/journal/journalcrawlerpublisher/repository/MemberRepository.java
+++ b/src/main/java/com/sw/journal/journalcrawlerpublisher/repository/MemberRepository.java
@@ -14,4 +14,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByNickname(String nickname);
     boolean existsByEmail(String email);
     boolean existsByUsername(String username);
+
+    // 유저 id 찾을 때
+    Optional<Member> findByEmail(String email);
 }


### PR DESCRIPTION
- 로그인 API 구현
- MemberRestController의 /verify-code 코드 수정
   - /verify-code-signup, /verify-code-change-pw 2개로 나눔
     (회원가입할 때, 비밀번호 재설정할 때 이메일 검증 성공하고 반환되는 메시지가 다름)
- 비밀번호 재설정할 때 현재 로그인 되어있는 사용자의 id가 아닌 RequestParam으로 사용자의 id를 받게끔 수정