### PR TITLE
[기능 개선] 쿼리 시간 개선

### DIFF
--- a/src/main/java/com/sw/journal/journalcrawlerpublisher/config/WebConfig.java
+++ b/src/main/java/com/sw/journal/journalcrawlerpublisher/config/WebConfig.java
@@ -13,7 +13,8 @@ public class WebConfig {
             @Override
             public void addCorsMappings(CorsRegistry registry) {
                 registry.addMapping("/**")
-                        .allowedOrigins("http://itscribe.site", "http://www.itscribe.site") // React 앱의 URL
+//                        .allowedOrigins("http://itscribe.site", "http://www.itscribe.site") // React 앱의 URL
+                        .allowedOrigins("http://localhost:3000") // 모든 URL
                         .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                         .allowedHeaders("*") // 모든 헤더를 허용
                         .allowCredentials(true); // 쿠키 및 인증 정보를 허용

--- a/src/main/java/com/sw/journal/journalcrawlerpublisher/controller/OurArticleController.java
+++ b/src/main/java/com/sw/journal/journalcrawlerpublisher/controller/OurArticleController.java
@@ -208,4 +208,22 @@ public class OurArticleController {
         private List<Long> categoryIds;
         private List<Long> tagCodes;
     }
+
+    @GetMapping("/ash-test")
+    public List<OurArticleWithTagsDTO> getTestRecentArticles() {
+        Pageable pageable = PageRequest.of(0, 18, Sort.by(Sort.Direction.DESC, "postDate"));
+        List<OurArticle> articles = ourArticleService.findAll(pageable).getContent();
+
+        return articles.stream()
+                .map(article -> {
+                    OurArticleWithTagsDTO dto = new OurArticleWithTagsDTO();
+                    dto.setId(article.getId());
+                    dto.setTitle(article.getTitle());
+                    dto.setContent(article.getContent());
+                    dto.setPostDate(article.getPostDate());
+                    dto.setCategory(article.getCategory());
+                    dto.setSource(article.getSource());
+                    return dto;
+                }).collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/sw/journal/journalcrawlerpublisher/controller/RecommendedArticleController.java
+++ b/src/main/java/com/sw/journal/journalcrawlerpublisher/controller/RecommendedArticleController.java
@@ -1,9 +1,6 @@
 package com.sw.journal.journalcrawlerpublisher.controller;
 
-import com.sw.journal.journalcrawlerpublisher.domain.Member;
-import com.sw.journal.journalcrawlerpublisher.domain.OurArticle;
-import com.sw.journal.journalcrawlerpublisher.domain.Image;
-import com.sw.journal.journalcrawlerpublisher.domain.UserFavoriteCategory;
+import com.sw.journal.journalcrawlerpublisher.domain.*;
 import com.sw.journal.journalcrawlerpublisher.dto.OurArticleWithTagsDTO;
 import com.sw.journal.journalcrawlerpublisher.repository.UserFavoriteCategoryRepository;
 import com.sw.journal.journalcrawlerpublisher.service.*;
@@ -16,7 +13,9 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -110,6 +109,60 @@ public class RecommendedArticleController {
                     dto.setImgUrls(imageService.findByArticle(article).stream()
                             .map(Image::getImgUrl)
                             .collect(Collectors.toList()));
+                    return dto;
+                }).collect(Collectors.toList());
+
+        return ResponseEntity.ok(articleDTOs);
+    }
+
+
+    @GetMapping("/recent-ash-test")
+    public ResponseEntity<List<OurArticleWithTagsDTO>> refinedGetArticlesByUserFavoriteCategories() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String currentUsername = authentication.getName();
+        Optional<Member> member = memberService.findByUsername(currentUsername);
+
+        if (!member.isPresent()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        Member foundMember = member.get();
+        List<OurArticle> articles;
+
+        // 유저 선호 카테고리가 있는지 확인
+        List<UserFavoriteCategory> favoriteCategories = userFavoriteCategoryRepository.findByMember(foundMember);
+        if (favoriteCategories.isEmpty()) {
+            // 선호 카테고리가 없을 경우 최근 기사 반환
+            articles = recommendArticleService.findRecentArticles(12);
+        } else {
+            // 선호 카테고리가 있을 경우 해당 카테고리의 기사 반환
+            articles = recommendArticleService.findByUserFavoriteCategories(foundMember);
+        }
+        List<Long> articleIds = articles.stream()
+                .map(OurArticle::getId)
+                .toList();
+
+        Map<Long, List<Tag>> articleTagsMap = tagService.findTagsByArticleIds(articleIds);
+        Map<Long, List<Image>> articleImageMap = imageService.findImagesByArticleIds(articleIds);
+
+        List<OurArticleWithTagsDTO> articleDTOs = articles.stream()
+                .map(article -> {
+                    OurArticleWithTagsDTO dto = new OurArticleWithTagsDTO();
+                    dto.setId(article.getId());
+                    dto.setTitle(article.getTitle());
+                    dto.setContent(article.getContent());
+                    dto.setPostDate(article.getPostDate());
+                    dto.setCategory(article.getCategory());
+                    dto.setSource(article.getSource());
+//                    dto.setTags(tagService.findByArticle(article));
+                    dto.setTags(articleTagsMap.getOrDefault(article.getId(), Collections.emptyList()));
+//                    dto.setImgUrls(imageService.findByArticle(article).stream()
+//                            .map(Image::getImgUrl)
+//                            .collect(Collectors.toList()));
+                    dto.setImgUrls(articleImageMap.getOrDefault(article.getId(), Collections.emptyList()).stream()
+                            .map(Image::getImgUrl)
+                            .collect(Collectors.toList()));
+
                     return dto;
                 }).collect(Collectors.toList());
 

--- a/src/main/java/com/sw/journal/journalcrawlerpublisher/domain/Image.java
+++ b/src/main/java/com/sw/journal/journalcrawlerpublisher/domain/Image.java
@@ -3,6 +3,7 @@ package com.sw.journal.journalcrawlerpublisher.domain;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.BatchSize;
 
 @Entity
 @Getter @Setter

--- a/src/main/java/com/sw/journal/journalcrawlerpublisher/domain/TagArticle.java
+++ b/src/main/java/com/sw/journal/journalcrawlerpublisher/domain/TagArticle.java
@@ -3,6 +3,7 @@ package com.sw.journal.journalcrawlerpublisher.domain;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.BatchSize;
 
 @Entity
 @Table(name = "tag_article")

--- a/src/main/java/com/sw/journal/journalcrawlerpublisher/repository/ImageRepository.java
+++ b/src/main/java/com/sw/journal/journalcrawlerpublisher/repository/ImageRepository.java
@@ -3,10 +3,14 @@ package com.sw.journal.journalcrawlerpublisher.repository;
 import com.sw.journal.journalcrawlerpublisher.domain.Image;
 import com.sw.journal.journalcrawlerpublisher.domain.OurArticle;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface ImageRepository extends JpaRepository<Image, Long> {
     List<Image> findByOurArticle(OurArticle ourArticle);
+    @Query("SELECT i FROM Image i where i.ourArticle.id IN :articleIds")
+    List<Image> findByArticleIds(@Param("articleIds") List<Long> articleIds);
 }

--- a/src/main/java/com/sw/journal/journalcrawlerpublisher/repository/OurArticleRepository.java
+++ b/src/main/java/com/sw/journal/journalcrawlerpublisher/repository/OurArticleRepository.java
@@ -5,6 +5,7 @@ import com.sw.journal.journalcrawlerpublisher.domain.OurArticle;
 import com.sw.journal.journalcrawlerpublisher.domain.Tag;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -16,13 +17,9 @@ import java.util.Optional;
 // wild-mantle 07-08
 @Repository
 public interface OurArticleRepository extends JpaRepository<OurArticle, Long> {
-
-
     // wild-mantle 07-16
     // 카테고리별 페이지네이션된 기사 검색
     Page<OurArticle> findByCategory(Category category, Pageable pageable);
-
-
 
     // 기사 URL로 기사 검색
     Optional<OurArticle> findBySource(String source);
@@ -89,4 +86,6 @@ public interface OurArticleRepository extends JpaRepository<OurArticle, Long> {
             "GROUP BY a " +
             "HAVING COUNT(DISTINCT ta.tag) = :tagCount")
     List<OurArticle> findByCategoriesAndTags(@Param("categories") List<Category> categories, @Param("tags") List<Tag> tags, @Param("tagCount") long tagCount);
+
+
 }

--- a/src/main/java/com/sw/journal/journalcrawlerpublisher/repository/TagArticleRepository.java
+++ b/src/main/java/com/sw/journal/journalcrawlerpublisher/repository/TagArticleRepository.java
@@ -4,9 +4,21 @@ import com.sw.journal.journalcrawlerpublisher.domain.OurArticle;
 import com.sw.journal.journalcrawlerpublisher.domain.Tag;
 import com.sw.journal.journalcrawlerpublisher.domain.TagArticle;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface TagArticleRepository extends JpaRepository<TagArticle, Long> {
     List<TagArticle> findByArticle(OurArticle article);
+
+
+    //SELECT Ta.*
+    // FROM TagArticle ta
+    // JOIN Tag t ON ta.tag_id = t.id
+    // WHERE ta.article_id IN (1,2,3)
+    @Query("SELECT ta FROM TagArticle ta " +
+            "JOIN FETCH ta.tag " +
+            "WHERE ta.article.id IN :articleIds")
+    List<TagArticle> findByArticleIds(@Param("articleIds") List<Long> articleIds);
 }

--- a/src/main/java/com/sw/journal/journalcrawlerpublisher/service/ImageService.java
+++ b/src/main/java/com/sw/journal/journalcrawlerpublisher/service/ImageService.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -15,5 +16,15 @@ public class ImageService {
 
     public List<Image> findByArticle(OurArticle ourArticle) {
         return imageRepository.findByOurArticle(ourArticle);
+    }
+
+    public Map<Long, List<Image>> findImagesByArticleIds(List<Long> articleIds) {
+        List<Image> images = imageRepository.findByArticleIds(articleIds);
+
+        return images.stream()
+                .collect(java.util.stream.Collectors.groupingBy(
+                        image -> image.getOurArticle().getId(),
+                        java.util.stream.Collectors.toList()
+                ));
     }
 }

--- a/src/main/java/com/sw/journal/journalcrawlerpublisher/service/TagService.java
+++ b/src/main/java/com/sw/journal/journalcrawlerpublisher/service/TagService.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
@@ -24,6 +25,16 @@ public class TagService {
         return tagArticleList.stream()
                 .map(TagArticle::getTag)
                 .collect(Collectors.toList());
+    }
+
+    public Map<Long, List<Tag>> findTagsByArticleIds(List<Long> articleIds) {
+        List<TagArticle> tagArticles = tagArticleRepository.findByArticleIds(articleIds);
+
+        return tagArticles.stream()
+                .collect(Collectors.groupingBy(
+                        tagArticle -> tagArticle.getArticle().getId(),
+                        Collectors.mapping(TagArticle::getTag, Collectors.toList())
+                ));
     }
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -33,3 +33,6 @@ spring.mail.properties.mail.smtp.starttls.enable=true
 #ProfileImage Path
 #upload.path=src/main/resources/images/
 upload.path=src/main/resources/static/images/
+
+spring.jpa.properties.hibernate.default_batch_fetch_size=30
+


### PR DESCRIPTION
RecommendedArticleController.java의 getArticlesByUserFavoriteCategories의 현재 쿼리 시간은 6.5초 가량인데 refinedGetArticlesByUserFavoriteCategories 메소드를 이용하면 2.3초 가량 시간을 줄였고, 쿼리는 여섯번밖에 일어나지 않음.

* TagArticleRepository 및 TagArticleService의 findAll method 개선 >> 한번만 쿼리해서 아이디의 모든 태그를 쿼리할 수 있게
* TagService의 findTagsByArticleIds 메소드 추가
* ImageRepository 및 imageService 개선 >> 상기와 동일
* 프로젝트 전역 배치 사이즈 변경 (30)
